### PR TITLE
switched to remote plugins

### DIFF
--- a/protobuf/buf.gen.yaml
+++ b/protobuf/buf.gen.yaml
@@ -1,15 +1,15 @@
 version: v1
 plugins:
-  - name: go
+  - remote: buf.build/protocolbuffers/plugins/go
     out: gen
     opt:
       - paths=source_relative
-  - name: go-grpc
+  - remote: buf.build/library/plugins/go-grpc:v1.1.0-2
     out: gen
     opt:
       - require_unimplemented_servers=false
       - paths=source_relative
-  - name: grpc-gateway
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.3-1
     out: gen
     opt:
       - paths=source_relative


### PR DESCRIPTION
switching to remote but plugins will allow for GitHub actions / workflows to use the buf generate / lint commands without needing to go get/install all protoc plugins (this was causing an issue in flagd git workflows)

Signed-off-by: James-Milligan <james@omnant.co.uk>