### PR TITLE
ci: removed buf push action to allow tag write

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -41,7 +41,5 @@ jobs:
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
       # Push module to the BSR
-      - uses: bufbuild/buf-push-action@v1
-        with:
-          input: protobuf
-          buf_token: ${{ secrets.BUF_TOKEN }}
+      - name: bsr-push
+        run: BUF_TOKEN="${{ secrets.BUF_TOKEN }}" buf push --tag "${{ needs.release-please.outputs.buf_release_tag }}" protobuf


### PR DESCRIPTION
Signed-off-by: James Milligan <james@omnant.co.uk>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- removes the bufbuild/buf-push-action@v1 action, allows for the release tag to be used within the BSR 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

