### PR TITLE
feat: Add ruby support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,6 @@ gen-csharp: install-buf guard-GOPATH
 
 gen-php: install-buf guard-GOPATH
 	${GOPATH}/bin/buf generate buf.build/open-feature/flagd --template protobuf/buf.gen.php.yaml
+
+gen-ruby: install-buf guard-GOPATH
+	${GOPATH}/bin/buf generate buf.build/open-feature/flagd --template protobuf/buf.gen.ruby.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # schemas
 
-Schemas and spec files pertaining to OpenFeature.  
+Schemas and spec files pertaining to OpenFeature.
 The Schema is available in the Buf Schema Registry, and can be found [here](https://buf.build/open-feature/flagd).
 
 <br />
@@ -76,4 +76,13 @@ Generate PHP stubs for grpc client
 
 ```
 make gen-php
+```
+
+
+## Ruby:
+
+Generate Ruby stubs for grpc client
+
+```
+make gen-ruby
 ```

--- a/protobuf/buf.gen.ruby.yaml
+++ b/protobuf/buf.gen.ruby.yaml
@@ -1,0 +1,6 @@
+version: v1
+plugins:
+  - remote: buf.build/grpc/plugins/ruby:v1.51.1-1
+    out: ../openfeature-flagd-provider/lib/openfeature/flagd/provider
+  - remote: buf.build/protocolbuffers/plugins/ruby:v21.10.0-1
+    out: ../openfeature-flagd-provider/lib/openfeature/flagd/provider

--- a/protobuf/schema/v1/schema.proto
+++ b/protobuf/schema/v1/schema.proto
@@ -8,6 +8,7 @@ option csharp_namespace = "OpenFeature.Flagd.Grpc";
 option go_package = "schema/service/v1";
 option java_package = "dev.openfeature.flagd.grpc";
 option php_namespace = "OpenFeature\\Providers\\Flagd\\Schema\\Grpc";
+option ruby_namespace = "openfeature/provider/flagd/v1/grpc"
 
 // Request body for bulk flag evaluation, used by the ResolveAll rpc.
 message ResolveAllRequest {

--- a/protobuf/schema/v1/schema.proto
+++ b/protobuf/schema/v1/schema.proto
@@ -8,7 +8,7 @@ option csharp_namespace = "OpenFeature.Flagd.Grpc";
 option go_package = "schema/service/v1";
 option java_package = "dev.openfeature.flagd.grpc";
 option php_namespace = "OpenFeature\\Providers\\Flagd\\Schema\\Grpc";
-option ruby_namespace = "openfeature/provider/flagd/v1/grpc";
+option ruby_package = "openfeature/provider/flagd/v1/grpc";
 
 // Request body for bulk flag evaluation, used by the ResolveAll rpc.
 message ResolveAllRequest {

--- a/protobuf/schema/v1/schema.proto
+++ b/protobuf/schema/v1/schema.proto
@@ -8,7 +8,7 @@ option csharp_namespace = "OpenFeature.Flagd.Grpc";
 option go_package = "schema/service/v1";
 option java_package = "dev.openfeature.flagd.grpc";
 option php_namespace = "OpenFeature\\Providers\\Flagd\\Schema\\Grpc";
-option ruby_namespace = "openfeature/provider/flagd/v1/grpc"
+option ruby_namespace = "openfeature/provider/flagd/v1/grpc";
 
 // Request body for bulk flag evaluation, used by the ResolveAll rpc.
 message ResolveAllRequest {


### PR DESCRIPTION
Signed-off-by: Jose Colella <jose.colella@gusto.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Adds ruby support for grpc schemas for the flagd provider

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

References [#releasehttps://github.com/open-feature/ruby-sdk-contrib/issues/1](https://github.com/open-feature/ruby-sdk-contrib/issues/1)

### Notes

Thanks to @toddbaert for the pairing

### Follow-up Tasks

- Add flagd provider for ruby, and add these schemas as submodule

### How to test

> make gen-ruby


