### PR TITLE
feat: fetch all flags rpc for sync server

### DIFF
--- a/protobuf/buf.md
+++ b/protobuf/buf.md
@@ -21,11 +21,18 @@ a supported plugin for generating connect stubs then it is recommended to use th
 
 ## Flag sync
 
-The module `sync.v1` is a grpc server streaming service definition to provide flagd with feature flag configurations.
-This service exposes a single method `SyncFlags`. Flagd acts as the client and initiates the streaming with `SyncFlagsRequest`.
+The module `sync.v1` is a service definition to provide flagd with feature flag configurations.
+The server exposes 2 `rpcs`.
 
+### SyncFlags
+Flagd acts as the client and initiates the streaming with `SyncFlagsRequest`.
 The server implementation will then stream feature flag configurations through `SyncFlagsResponse`. The response contains
 `SyncState` which can be utilized to provide flagd with flexible configuration updates.
+
+### FetchAllFlags
+Flagd acts as the client and sends the empty message `FetchAllFlagsRequest`.
+The server implementation responds with the full feature flag configuration through the `FetchAllFlagsResponse`.
+This `rpc` is used to re-sync flagd's internal state during configuration merge events.
 
 ## Code generation
 

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -46,7 +46,17 @@ message SyncFlagsResponse {
   SyncState state = 2;
 }
 
+// FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state
+message FetchAllFlagsRequest {}
+
+//  FetchAllFlagsResponse is the server response containing feature flag configurations
+message FetchAllFlagsResponse {
+  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
+  string flag_configuration = 1;
+}
+
 // FlagService implements a server streaming to provide realtime flag configurations
 service FlagSyncService {
   rpc SyncFlags(SyncFlagsRequest) returns (stream SyncFlagsResponse) {}
+  rpc FetchAllFlags(FetchAllFlagsRequest) returns (FetchAllFlagsResponse) {}
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds the fetch all flags rpc for sync server, required for flagd to resend state on merge events

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

