### PR TITLE
feat: extend stream sync response to have error response

### DIFF
--- a/protobuf/buf.md
+++ b/protobuf/buf.md
@@ -26,8 +26,13 @@ The server exposes 2 `rpcs`.
 
 ### SyncFlags
 Flagd acts as the client and initiates the streaming with `SyncFlagsRequest`.
-The server implementation will then stream feature flag configurations through `SyncFlagsResponse`. The response contains
-`SyncState` which can be utilized to provide flagd with flexible configuration updates.
+The server implementation will then stream feature flag configurations through `SyncFlagsResponse`. The response is 
+either a `SyncPayload` (`sync`)  or a `google.rpc.Status` (`error`). 
+
+`SyncPayload` contain flag configurations as a string and `SyncState` which can be utilized to provide flagd with 
+flexible flag configuration updates.
+
+Errors are communicated through `google.rpc.Status` and client should expect a connection termination.
 
 ### FetchAllFlags
 Flagd acts as the client and sends the empty message `FetchAllFlagsRequest`.

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/rpc/status.proto";
+
 package sync.v1;
 
 option go_package = "flagd/grpcsync";
@@ -36,14 +38,25 @@ enum SyncState {
   SYNC_STATE_PING = 5;
 }
 
-// SyncFlagsResponse is the server response containing feature flag configurations and the state
-message SyncFlagsResponse {
+// SyncPayload represents a successful sync response
+message SyncPayload {
   // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
   string flag_configuration = 1;
 
   // State conveying the operation to be performed by flagd. See the descriptions of SyncState for an explanation of
   // supported values
   SyncState state = 2;
+}
+
+// SyncFlagsResponse is the server response for grpc sync
+message SyncFlagsResponse {
+  oneof response {
+    // Sync response
+    SyncPayload sync = 1;
+
+    // Error response. Client should expect a connection termination when error is returned
+    google.rpc.Status error = 2;
+  }
 }
 
 // FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state


### PR DESCRIPTION
## This PR

Introduce error response capability to grpc stream response. Error handling is inspired by grpc documentation [1].


[1] - https://grpc.io/docs/guides/error/#richer-error-model 