### PR TITLE
chore: configure prost and tonic plugins for rust

### DIFF
--- a/protobuf/buf.gen.rust.yaml
+++ b/protobuf/buf.gen.rust.yaml
@@ -3,5 +3,8 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - plugin: buf.build/community/neoeinstein-prost
+ # Requires protoc-gen-tonic & protoc-gen-prost to enable service client creation
+  - name: prost
+    out: ../proto/rust
+  - name: tonic
     out: ../proto/rust


### PR DESCRIPTION
This change generates the service client for the tonic GRPCv2 framework
```
pub mod service_client {
    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
    use tonic::codegen::*;
    use tonic::codegen::http::Uri;
    /** Service defines the exposed rpcs of flagd
*/
    #[derive(Debug, Clone)]
    pub struct ServiceClient<T> {
        inner: tonic::client::Grpc<T>,
    }
    impl ServiceClient<tonic::transport::Channel> {
        /// Attempt to create a new client by connecting to a given endpoint.
        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
        where
```