### PR TITLE
feat: introduce provider_id to sync service FetchAllFlags

### DIFF
--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -6,7 +6,7 @@ option go_package = "flagd/grpcsync";
 
 // SyncFlagsRequest is the request initiating the sever-streaming rpc. Flagd sends this request, acting as the client
 message SyncFlagsRequest {
-  // Optional: A unique identifier for flagd  provider (grpc client) initiating the request. The server implementations
+  // Optional: A unique identifier for flagd provider (grpc client) initiating the request. The server implementations
   // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
   // is intended to be optional. However server implementation may enforce it.
   string provider_id = 1;
@@ -48,7 +48,7 @@ message SyncFlagsResponse {
 
 // FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state
 message FetchAllFlagsRequest {
-  // Optional: A unique identifier for flagd  provider (grpc client) initiating the request. The server implementations
+  // Optional: A unique identifier for flagd provider (grpc client) initiating the request. The server implementations
   // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
   // is intended to be optional. However server implementation may enforce it.
   string provider_id = 1;

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -48,10 +48,10 @@ message SyncFlagsResponse {
 
 // FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state
 message FetchAllFlagsRequest {
-    // Optional: A unique identifier for flagd  provider (grpc client) initiating the request. The server implementations
-    // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
-    // is intended to be optional. However server implementation may enforce it.
-    string provider_id = 1;
+  // Optional: A unique identifier for flagd  provider (grpc client) initiating the request. The server implementations
+  // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
+  // is intended to be optional. However server implementation may enforce it.
+  string provider_id = 1;
 }
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -47,7 +47,12 @@ message SyncFlagsResponse {
 }
 
 // FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state
-message FetchAllFlagsRequest {}
+message FetchAllFlagsRequest {
+    // Optional: A unique identifier for flagd  provider (grpc client) initiating the request. The server implementations
+    // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
+    // is intended to be optional. However server implementation may enforce it.
+    string provider_id = 1;
+}
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations
 message FetchAllFlagsResponse {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- introduces the `provider_id` field to the `FetchAllFlagsRequest` message

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

