### PR TITLE
feat: introduce selector field to requests

### DIFF
--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -6,10 +6,18 @@ option go_package = "flagd/grpcsync";
 
 // SyncFlagsRequest is the request initiating the sever-streaming rpc. Flagd sends this request, acting as the client
 message SyncFlagsRequest {
-  // Optional: A unique identifier for flagd provider (grpc client) initiating the request. The server implementations
-  // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
-  // is intended to be optional. However server implementation may enforce it.
+  // Optional: A unique identifier for flagd(grpc client) initiating the request. The server implementations may
+  // utilize this identifier to uniquely identify, validate(ex:- enforce authentication/authorization) and filter
+  // flag configurations that it can expose to this request. This field is intended to be optional. However server
+  // implementations may enforce it.
+  //    ex:- provider_id: flagd-weatherApp-sidecar
   string provider_id = 1;
+
+  // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
+  // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
+  // filtering mechanism.
+  //    ex:- filtering: 'source=database,key=weatherApp'
+  string filtering = 2;
 }
 
 // SyncState conveys the state of the payload. These states are related to flagd isync.go type definitions but
@@ -48,10 +56,18 @@ message SyncFlagsResponse {
 
 // FetchAllFlagsRequest is the request to fetch all flags. Flagd sends this request as the client in order to resync its internal state
 message FetchAllFlagsRequest {
-  // Optional: A unique identifier for flagd provider (grpc client) initiating the request. The server implementations
-  // can utilize this identifier to aggregate flag configurations and stream them to a specific client. This identifier
-  // is intended to be optional. However server implementation may enforce it.
+  // Optional: A unique identifier for flagd(grpc client) initiating the request. The server implementations may
+  // utilize this identifier to uniquely identify, validate(ex:- enforce authentication/authorization) and filter
+  // flag configurations that it can expose to this request. This field is intended to be optional. However server
+  // implementations may enforce it.
+  //    ex:- provider_id: flagd-weatherApp-sidecar
   string provider_id = 1;
+
+  // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
+  // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
+  // filtering mechanism.
+  //    ex:- filtering: 'source=database,key=weatherApp'
+  string filtering = 2;
 }
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -13,11 +13,11 @@ message SyncFlagsRequest {
   //    ex:- provider_id: flagd-weatherapp-sidecar
   string provider_id = 1;
 
-  // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
+  // Optional: A selector for the flag configuration request. The server implementation may utilize this to select
   // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
   // filtering mechanism.
-  //    ex:- filter: 'source=database,app=weatherapp'
-  string filter = 2;
+  //    ex:- selector: 'source=database,app=weatherapp'
+  string selector = 2;
 }
 
 // SyncState conveys the state of the payload. These states are related to flagd isync.go type definitions but
@@ -63,11 +63,11 @@ message FetchAllFlagsRequest {
   //    ex:- provider_id: flagd-weatherapp-sidecar
   string provider_id = 1;
 
-  // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
+  // Optional: A selector for the flag configuration request. The server implementation may utilize this to select
   // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
   // filtering mechanism.
-  //    ex:- filter: 'source=database,app=weatherapp'
-  string filter = 2;
+  //    ex:- selector: 'source=database,app=weatherapp'
+  string selector = 2;
 }
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -10,14 +10,14 @@ message SyncFlagsRequest {
   // utilize this identifier to uniquely identify, validate(ex:- enforce authentication/authorization) and filter
   // flag configurations that it can expose to this request. This field is intended to be optional. However server
   // implementations may enforce it.
-  //    ex:- provider_id: flagd-weatherApp-sidecar
+  //    ex:- provider_id: flagd-weatherapp-sidecar
   string provider_id = 1;
 
   // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
   // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
   // filtering mechanism.
-  //    ex:- filtering: 'source=database,key=weatherApp'
-  string filtering = 2;
+  //    ex:- filter: 'source=database,app=weatherapp'
+  string filter = 2;
 }
 
 // SyncState conveys the state of the payload. These states are related to flagd isync.go type definitions but
@@ -60,14 +60,14 @@ message FetchAllFlagsRequest {
   // utilize this identifier to uniquely identify, validate(ex:- enforce authentication/authorization) and filter
   // flag configurations that it can expose to this request. This field is intended to be optional. However server
   // implementations may enforce it.
-  //    ex:- provider_id: flagd-weatherApp-sidecar
+  //    ex:- provider_id: flagd-weatherapp-sidecar
   string provider_id = 1;
 
   // Optional: A filtering key for the flag configuration request. The server implementation may utilize this to filter
   // flag configurations from a collection, select the source of the flag or combine this to any desired underlying
   // filtering mechanism.
-  //    ex:- filtering: 'source=database,key=weatherApp'
-  string filtering = 2;
+  //    ex:- filter: 'source=database,app=weatherapp'
+  string filter = 2;
 }
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations


### PR DESCRIPTION
## This PR

Introduces an optional filtering field to grpc requests. 

The intended usage of the new field: `selector `

```
Optional: A selector for the flag configuration request. The server implementation may utilize this to select
flag configurations from a collection, select the source of the flag or combine this to any desired underlying
filtering mechanism.
   ex:- selector: 'source=database,app=weatherapp'
```
For example, flagd could utilize this filtering field to point out the K8s CRD when connecting to kube-proxy [1]

[1] - https://github.com/open-feature/flagd/pull/495 