### PR TITLE
feat!: migrate to buf managed plugins

### DIFF
--- a/protobuf/buf.gen.csharp.yaml
+++ b/protobuf/buf.gen.csharp.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/csharp:v21.7.0-1
+  - plugin: buf.build/protocolbuffers/csharp:v23.4
     out: ../proto/csharp
-  - remote: buf.build/grpc/plugins/csharp:v1.49.1-1
+  - plugin: buf.build/grpc/csharp:v1.56.0
     out: ../proto/csharp

--- a/protobuf/buf.gen.go-server.yaml
+++ b/protobuf/buf.gen.go-server.yaml
@@ -2,16 +2,16 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/go:v1.28.0-1
+  - plugin: buf.build/protocolbuffers/go:v1.31.0
     out: ../proto/go-server
     opt:
       - paths=source_relative
-  - remote: buf.build/library/plugins/go-grpc:v1.1.0-2
+  - plugin: buf.build/grpc/go:v1.3.0
     out: ../proto/go-server
     opt:
       - require_unimplemented_servers=false
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.3-1
+  - plugin: buf.build/grpc-ecosystem/gateway:v2.16.0
     out: ../proto/go-server
     opt:
       - paths=source_relative

--- a/protobuf/buf.gen.go.yaml
+++ b/protobuf/buf.gen.go.yaml
@@ -2,11 +2,11 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/go:v1.28.0-1
+  - plugin: buf.build/protocolbuffers/go:v1.31.0
     out: ../proto/go
     opt:
       - paths=source_relative
-  - remote: buf.build/library/plugins/go-grpc:v1.1.0-2
+  - plugin: buf.build/grpc/go:v1.3.0
     out: ../proto/go
     opt:
       - require_unimplemented_servers=false

--- a/protobuf/buf.gen.java.yaml
+++ b/protobuf/buf.gen.java.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v21.4.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: ../proto/java
-  - remote: buf.build/grpc/plugins/java:v1.48.0-1
+  - plugin: buf.build/grpc/java:v1.56.1
     out: ../proto/java

--- a/protobuf/buf.gen.php.yaml
+++ b/protobuf/buf.gen.php.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc/plugins/php:v1.50.0-1
+  - plugin: buf.build/grpc/php:v1.56.0
     out: ../proto/php
-  - remote: buf.build/protocolbuffers/plugins/php:v21.8.0-1
+  - plugin: buf.build/protocolbuffers/php:v23.4
     out: ../proto/php

--- a/protobuf/buf.gen.python.yaml
+++ b/protobuf/buf.gen.python.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/python:v21.8.0-1
+  - plugin: buf.build/protocolbuffers/python:v23.4
     out: ../proto/python
-  - remote: buf.build/grpc/plugins/python:v1.50.0-1
+  - plugin: buf.build/grpc/python:v1.56.0
     out: ../proto/python

--- a/protobuf/buf.gen.ruby.yaml
+++ b/protobuf/buf.gen.ruby.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc/plugins/ruby:v1.51.1-1
+  - plugin: buf.build/grpc/ruby:v1.56.0
     out: ./lib/openfeature/flagd/provider
-  - remote: buf.build/protocolbuffers/plugins/ruby:v21.10.0-1
+  - plugin: buf.build/protocolbuffers/ruby:v23.4
     out: ./lib/openfeature/flagd/provider

--- a/protobuf/buf.gen.ts-connect.yaml
+++ b/protobuf/buf.gen.ts-connect.yaml
@@ -1,10 +1,10 @@
 version: v1
 plugins:
-  - remote: buf.build/bufbuild/plugins/es:v0.1.1-1
+  - plugin: buf.build/bufbuild/es:v1.2.1
     out: ../proto/ts
     opt:
       - target=js+dts
-  - remote: buf.build/bufbuild/plugins/connect-web:v0.2.0-1
+  - plugin: buf.build/bufbuild/connect-es:v0.11.0
     out: ../proto/ts
     opt:
       - target=ts

--- a/protobuf/buf.gen.ts.yaml
+++ b/protobuf/buf.gen.ts.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/timostamm/plugins/protobuf-ts:v2.2.2-1
+  - plugin: buf.build/community/timostamm-protobuf-ts:v2.9.0
     out: ../proto/ts
     opt:
       - long_type_string


### PR DESCRIPTION
Migration as per https://buf.build/docs/migration-guides/migrate-remote-generation-alpha/

It looks like only the js-contrib use these directly (most use protoc and local generation except go-sdk-contribs which uses remote packages) but I've migrated everything as I think is appropriate. I've tested this locally in the js-contribs and it works as expected