### PR TITLE
feat: introduce flagd evaluation metadata

### DIFF
--- a/protobuf/schema/v1/schema.proto
+++ b/protobuf/schema/v1/schema.proto
@@ -58,6 +58,9 @@ message ResolveBooleanResponse {
 
   // The variant name of the returned flag value.
   string variant = 3;
+
+  // Metadata for this evaluation
+  google.protobuf.Struct metadata = 4;
 }
 
 // Request body for string flag evaluation, used by the ResolveString rpc.
@@ -79,6 +82,9 @@ message ResolveStringResponse {
 
   // The variant name of the returned flag value.
   string variant = 3;
+
+  // Metadata for this evaluation
+  google.protobuf.Struct metadata = 4;
 }
 
 // Request body for float flag evaluation, used by the ResolveFloat rpc.
@@ -100,6 +106,9 @@ message ResolveFloatResponse {
 
   // The variant name of the returned flag value.
   string variant = 3;
+
+  // Metadata for this evaluation
+  google.protobuf.Struct metadata = 4;
 }
 
 // Request body for int flag evaluation, used by the ResolveInt rpc.
@@ -121,6 +130,9 @@ message ResolveIntResponse {
 
   // The variant name of the returned flag value.
   string variant = 3;
+
+  // Metadata for this evaluation
+  google.protobuf.Struct metadata = 4;
 }
 
 // Request body for object flag evaluation, used by the ResolveObject rpc.
@@ -144,6 +156,9 @@ message ResolveObjectResponse {
 
   // The variant name of the returned flag value.
   string variant = 3;
+
+  // Metadata for this evaluation
+  google.protobuf.Struct metadata = 4;
 }
 
 // Response body for the EventStream stream response


### PR DESCRIPTION
## This PR

Introduce flag evaluation `metadata` which can be mapped to flag metadata field of resolution details defined through OF Specification [1]

This is non-breaking as we are not violating any proto restrictions [2]

[1] - https://github.com/open-feature/spec/blob/main/specification/types.md#resolution-details 
[2] - https://protobuf.dev/programming-guides/proto3/#updating 