### PR TITLE
feat!: use ts-proto for node

### DIFF
--- a/protobuf/buf.gen.ts.yaml
+++ b/protobuf/buf.gen.ts.yaml
@@ -1,7 +1,8 @@
 version: v1
 plugins:
-  - plugin: buf.build/community/timostamm-protobuf-ts:v2.9.0
+  - plugin: buf.build/community/stephenh-ts-proto:v1.156.0
     out: ../proto/ts
-    opt:
-      - long_type_string
-      - generate_dependencies
+    opt: 
+      - outputServices=grpc-js
+      - forceLong=string
+      - esModuleInterop=true


### PR DESCRIPTION
This plugin is 3 times more popular than what we're using, and has more features. I've updated the provider to use it [here](https://github.com/open-feature/js-sdk-contrib/pull/484).