### PR TITLE
feat!: add language packaging options for sync proto

### DIFF
--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -2,7 +2,11 @@ syntax = "proto3";
 
 package sync.v1;
 
+option csharp_namespace = "OpenFeature.Flagd.Sync";
 option go_package = "flagd/grpcsync";
+option java_package = "dev.openfeature.flagd.sync";
+option php_namespace = "OpenFeature\\Providers\\Flagd\\Schema\\Sync";
+option ruby_package = "OpenFeature::FlagD::Provider::Sync";
 
 // SyncFlagsRequest is the request initiating the sever-streaming rpc. Flagd sends this request, acting as the client
 message SyncFlagsRequest {


### PR DESCRIPTION
Adds appropriate packaging/naming for multiple languages for the sync proto.

This is technically breaking because the generated sync code will have different packages, but besides Go (which didn't change) such sources aren't in use anywhere (this is highlighted by the [buf check](https://github.com/open-feature/schemas/actions/runs/5940673408/job/16109777269?pr=102)).