### PR TITLE
chore: Bump Buf ver installed from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUF_VERSION=v1.6.0
+BUF_VERSION=v1.26.1
 
 guard-%:
 	@ if [ "${${*}}" = "" ]; then \


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Bumps the version of the Buf tool installed by Makefile to latest

### Related Issues
- Current version of Buf (1.6.0) can't parse some of the template YAMLs from this repo; e.g. the `plugin` entry is [not available](https://github.com/bufbuild/buf/blob/25520a3fb15c8fab140e76e7238e6ace8dac13d9/private/buf/bufgen/bufgen.go#L270-L277) under `plugins`, in version 1.6.0

### How to test
Running `make gen-java` works on my machine after the version bump
